### PR TITLE
Test custom serialization using stdlib

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,3 @@ gem "rake"
 gem "rspec", "~> 3"
 gem "dalli", "< 3"
 gem "activesupport", "~> 6.0" # 7 does not support old rubies TODO: setup multiple gemfiles
-gem "oj"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,6 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     minitest (5.15.0)
-    oj (3.14.2)
     rake (13.0.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -46,7 +45,6 @@ DEPENDENCIES
   bump
   dalli (< 3)
   large_object_store!
-  oj
   rake
   rspec (~> 3)
 

--- a/spec/large_object_store_spec.rb
+++ b/spec/large_object_store_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 require "active_support/cache"
 require "active_support/notifications"
 require "active_support/cache/dalli_store"
-require "oj"
+require "yaml"
 
 describe LargeObjectStore do
   # flag is in first position for single page values and after the uuid for multi page values
@@ -263,14 +263,14 @@ describe LargeObjectStore do
       end
 
       describe "when a custom serializer is specified" do
-        let(:store) { LargeObjectStore.wrap(cache, serializer: Oj) }
+        let(:store) { LargeObjectStore.wrap(cache, serializer: YAML) }
 
         it "uses the custom serializer" do
           value = { "foo" => "bar" }
-          json = Oj.dump(value)
-          expect(Oj).to receive(:dump).with(value).and_call_original
+          json = YAML.dump(value)
+          expect(YAML).to receive(:dump).with(value).and_call_original
           store.fetch("a") { value }
-          expect(Oj).to receive(:load).with(json).and_call_original
+          expect(YAML).to receive(:load).with(json).and_call_original
           expect(store.read("a")).to eq(value)
         end
       end


### PR DESCRIPTION
Oj is fast to use, but slow to install. Let's test with a readily available serialization library instead.