### PR TITLE
Add GHA workflow for ruby gem publication

### DIFF
--- a/.github/workflows/ruby-gem-publication.yml
+++ b/.github/workflows/ruby-gem-publication.yml
@@ -1,0 +1,12 @@
+name: Ruby Gem Publish
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+    secrets:
+      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}


### PR DESCRIPTION
This adds a GHA workflow -  to automate publishing the Gem to RubyGems when a commit is tagged with something beginning with v.