### PR TITLE
Consider presence of namespace when computing slice size

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    large_object_store (1.6.0)
+    large_object_store (1.6.1)
       zstd-ruby (~> 1.5.5)
 
 GEM

--- a/lib/large_object_store.rb
+++ b/lib/large_object_store.rb
@@ -38,7 +38,9 @@ module LargeObjectStore
 
       # calculate slice size; note that key length is a factor because
       # the key is stored on the same slab page as the value
-      slice_size = MAX_OBJECT_SIZE - ITEM_HEADER_SIZE - UUID_SIZE - key.bytesize
+      namespace = (store.respond_to?(:options) && store.options[:namespace]) || ""
+      namespace_length = namespace.empty? ? 0 : namespace.size + 1
+      slice_size = MAX_OBJECT_SIZE - ITEM_HEADER_SIZE - UUID_SIZE - key.bytesize - namespace_length
 
       # store number of pages
       pages = (value.size / slice_size.to_f).ceil

--- a/lib/large_object_store/version.rb
+++ b/lib/large_object_store/version.rb
@@ -1,3 +1,3 @@
 module LargeObjectStore
-  VERSION = "1.6.0"
+  VERSION = "1.6.1"
 end


### PR DESCRIPTION
The existing logic to determine the maximum slice size for an object was not taking in to consideration if the key name was prefixed with a namespace, which led to being able to generate key-value pairs that were too large for memcached in some edge cases