### PR TITLE
custom slice size

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    large_object_store (1.6.1)
+    large_object_store (1.7.0)
       zstd-ruby (~> 1.5.5)
 
 GEM

--- a/lib/large_object_store/version.rb
+++ b/lib/large_object_store/version.rb
@@ -1,3 +1,3 @@
 module LargeObjectStore
-  VERSION = "1.6.1"
+  VERSION = "1.7.0"
 end


### PR DESCRIPTION
Depending on usage patterns, hot keys of 1MiB can easily deplete the network capacity of a node. This PR allows for better large key distribution by providing the client with an option to set the max_slice_size