### PR TITLE
Remove warnings

### DIFF
--- a/large_object_store.gemspec
+++ b/large_object_store.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new name, LargeObjectStore::VERSION do |s|
   s.files = `git ls-files lib Readme.md`.split("\n")
   s.license = "MIT"
   s.required_ruby_version = '>= 3.0'
-  s.add_runtime_dependency('zstd-ruby', '~> 1.5.5')
+  s.add_runtime_dependency('zstd-ruby', '~> 1.5.6', '>= 1.5.6.2')
 end

--- a/lib/large_object_store.rb
+++ b/lib/large_object_store.rb
@@ -142,7 +142,7 @@ module LargeObjectStore
 
     def compress(value, options)
       if options[:zstd]
-        Zstd.compress(value, ZSTD_COMPRESS_LEVEL)
+        Zstd.compress(value, level: ZSTD_COMPRESS_LEVEL)
       else
         Zlib::Deflate.deflate(value)
       end

--- a/spec/large_object_store_spec.rb
+++ b/spec/large_object_store_spec.rb
@@ -34,6 +34,7 @@ describe LargeObjectStore do
     stores << ActiveSupport::Cache::DalliStore.new("localhost:#{ENV["MEMCACHED_PORT"] || "11211"}")
     warn "Using ActiveSupport::Cache::DalliStore from dalli v2.x"
   rescue LoadError
+    ActiveSupport.cache_format_version = "#{ActiveSupport::VERSION::MAJOR}.#{ActiveSupport::VERSION::MINOR}".to_f if ActiveSupport.respond_to?(:cache_format_version=)
     stores << ActiveSupport::Cache::MemCacheStore.new("localhost:#{ENV["MEMCACHED_PORT"] || "11211"}")
   end
 


### PR DESCRIPTION
- Remove ActiveSupport warnings when testing with Rails 7+
- Remove warnings when using zstd-ruby v1.5.6.2+ with old syntax.